### PR TITLE
feat: link uploaded assets to xblock state

### DIFF
--- a/imagesgallery/imagesgallery.py
+++ b/imagesgallery/imagesgallery.py
@@ -28,16 +28,6 @@ except ImportError:
     contentstore = None
     AssetKey = None
 
-# Temporary fix for supporting both contentstore assets management versions (master / Palm)
-try:
-    from cms.djangoapps.contentstore.views.assets import update_course_run_asset, delete_asset
-except ImportError:
-    from cms.djangoapps.contentstore.asset_storage_handler import update_course_run_asset, delete_asset
-except ModuleNotFoundError:
-    # Avoid errors while running tests
-    update_course_run_asset = None
-    delete_asset = None
-
 log = logging.getLogger(__name__)
 
 
@@ -221,6 +211,11 @@ class ImagesGalleryXBlock(XBlock):
     @XBlock.handler
     def file_upload(self, request, suffix=''):  # pylint: disable=unused-argument
         """Handler for file upload to the course assets."""
+        # Temporary fix for supporting both contentstore assets management versions (master / Palm)
+        try:
+            from cms.djangoapps.contentstore.views.assets import update_course_run_asset  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            from cms.djangoapps.contentstore.asset_storage_handler import update_course_run_asset  # pylint: disable=import-outside-toplevel
         uploaded_content = []
         for _, file in request.params.items():
             try:
@@ -257,6 +252,10 @@ class ImagesGalleryXBlock(XBlock):
     @XBlock.json_handler
     def remove_files(self, data, suffix=''):  # pylint: disable=unused-argument
         """Handler for removing images from the course assets."""
+        try:
+            from cms.djangoapps.contentstore.views.assets import delete_asset  # pylint: disable=import-outside-toplevel
+        except ImportError:
+            from cms.djangoapps.contentstore.asset_storage_handler import delete_asset  # pylint: disable=import-outside-toplevel
         asset_key = AssetKey.from_string(data.get("asset_key"))
         try:
             delete_asset(self.course_id, asset_key)

--- a/imagesgallery/imagesgallery.py
+++ b/imagesgallery/imagesgallery.py
@@ -33,6 +33,10 @@ try:
     from cms.djangoapps.contentstore.views.assets import update_course_run_asset, delete_asset
 except ImportError:
     from cms.djangoapps.contentstore.asset_storage_handler import update_course_run_asset, delete_asset
+except ModuleNotFoundError:
+    # Avoid errors while running tests
+    update_course_run_asset = None
+    delete_asset = None
 
 log = logging.getLogger(__name__)
 

--- a/imagesgallery/imagesgallery.py
+++ b/imagesgallery/imagesgallery.py
@@ -236,11 +236,14 @@ class ImagesGalleryXBlock(XBlock):
     @XBlock.json_handler
     def get_files(self, data, suffix=''):  # pylint: disable=unused-argument
         """Handler for getting images from the course assets."""
-        import pudb; pu.db
-        return self.get_paginated_contents(
+        paginated_contents = self.get_paginated_contents(
             current_page=int(data.get("current_page", 0)),
             page_size=int(data.get("page_size", 10)),
         )
+        return {
+            "files": paginated_contents,
+            "total_count": len(paginated_contents),
+        }
 
     @XBlock.json_handler
     def remove_files(self, data, suffix=''):  # pylint: disable=unused-argument

--- a/imagesgallery/imagesgallery.py
+++ b/imagesgallery/imagesgallery.py
@@ -252,13 +252,14 @@ class ImagesGalleryXBlock(XBlock):
         """Handler for removing images from the course assets."""
         asset_key = AssetKey.from_string(data.get("asset_key"))
         # Temporary fix for supporting both contentstore assets management versions (master / Palm)
+        from cms.djangoapps.contentstore.exceptions import AssetNotFoundException  # pylint: disable=import-outside-toplevel
         try:
             from cms.djangoapps.contentstore.asset_storage_handler import delete_asset  # pylint: disable=import-outside-toplevel
         except ImportError:
             from cms.djangoapps.contentstore.views.assets import delete_asset  # pylint: disable=import-outside-toplevel
         try:
             delete_asset(self.course_id, asset_key)
-        except Exception as e:  # pylint: disable=broad-except
+        except AssetNotFoundException as e:  # pylint: disable=broad-except
             log.exception(e)
 
         for content in self.contents:

--- a/imagesgallery/imagesgallery.py
+++ b/imagesgallery/imagesgallery.py
@@ -281,21 +281,6 @@ class ImagesGalleryXBlock(XBlock):
             "thumbnail": urljoin(configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL), thumbnail_url),
         }
 
-    def get_asset_json_from_dict(self, asset):
-        """Transform the asset dictionary into a JSON serializable object."""
-        asset_url = StaticContent.serialize_asset_key_with_slash(asset["asset_key"])
-        thumbnail_url = self._get_thumbnail_asset_key(asset)
-        return {
-            "id": asset["_id"],
-            "asset_key": str(asset["asset_key"]),
-            "display_name": asset["displayname"],
-            "url": str(asset_url),
-            "content_type": asset["contentType"],
-            "file_size": asset["length"],
-            "external_url": urljoin(configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL), asset_url),
-            "thumbnail": urljoin(configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL), thumbnail_url),
-        }
-
     def _get_thumbnail_asset_key(self, asset):
         """Return the thumbnail asset key."""
         thumbnail_location = asset.get('thumbnail_location', None)
@@ -311,23 +296,6 @@ class ImagesGalleryXBlock(XBlock):
         Returns the contents list.
         """
         return self.contents[current_page * page_size: (current_page + 1) * page_size]
-
-    # def get_paginated_contents(self, current_page=0, page_size=10):
-    #     """Return the assets paginated list."""
-    #     query_options = {
-    #         "current_page": current_page,
-    #         "page_size": page_size,
-    #         "sort": {},
-    #         "filter_params": IMAGE_CONTENT_TYPE_FOR_MONGO,
-    #     }
-    #     assets, total_count = self._get_assets_for_page(self.course_id, query_options)
-    #     serialized_assets = []
-    #     for asset in assets:
-    #         serialized_assets.append(self.get_asset_json_from_dict(asset))
-    #     return {
-    #         "files": serialized_assets,
-    #         "total_count": total_count,
-    #     }
 
     def _get_assets_for_page(self, course_key, options):
         """Return course content for given course and options."""


### PR DESCRIPTION
## Description
This PR links assets to the Xblock used for the upload. This way, when displaying the xblock in the LMS, the only images shown were uploaded using the xblock instead of all images from the course assets.

## How to test
1. Install the xblock using this branch in the LMS/CMS
2. Restart both services
3. Add the xblock to your courses' advanced list: `imagesgallery`
4. Create a new course component with the xblock
5. Upload your images
6. Check the course assets, the new images should be there
7. Go to the LMS as a student, the only images displayed are the previously uploaded images

Since this xblock is still a work in progress, if there's an error or the xblock doesn't update correctly, then use ctrl + shift + R. 