### PR TITLE
fix: correct image deletion functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Unreleased
 
 *
 
+0.4.2 - 2023-11-16
+**********************************************
+
+Changed
+=======
+
+* Update documentation
+* Correct image deletion functionality
+
 0.4.1 - 2023-10-24
 **********************************************
 

--- a/imagesgallery/__init__.py
+++ b/imagesgallery/__init__.py
@@ -4,4 +4,4 @@ Init for the ImagesGalleryXBlock package.
 
 from .imagesgallery import ImagesGalleryXBlock
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'

--- a/imagesgallery/imagesgallery.py
+++ b/imagesgallery/imagesgallery.py
@@ -261,6 +261,7 @@ class ImagesGalleryXBlock(XBlock):
     @XBlock.json_handler
     def get_files(self, data, suffix=''):  # pylint: disable=unused-argument
         """Handler for getting images from the course assets."""
+        self.sync_course_assets()
         paginated_contents = self.get_paginated_contents(
             current_page=int(data.get("current_page", 0)),
             page_size=int(data.get("page_size", 10)),
@@ -314,6 +315,21 @@ class ImagesGalleryXBlock(XBlock):
         Returns the contents list.
         """
         return self.contents[current_page * page_size: (current_page + 1) * page_size]
+
+    def sync_course_assets(self):
+        """Sync course assets."""
+        course_assets_id = self.get_all_course_assets_id()
+
+        for content in self.contents:
+            if content["id"] not in course_assets_id:
+                print("Content not found in course assets, removing it from the list.")
+                self.contents.remove(content)
+                self.content_names.remove(content["display_name"])
+
+    def get_all_course_assets_id(self):
+        """Return all course assets id."""
+        course_assets, _ = contentstore().get_all_content_for_course(self.course_id)
+        return [asset["_id"] for asset in course_assets]
 
     def _get_assets_for_page(self, course_key, options):
         """Return course content for given course and options."""

--- a/imagesgallery/imagesgallery.py
+++ b/imagesgallery/imagesgallery.py
@@ -16,13 +16,11 @@ from xblockutils.resources import ResourceLoader
 
 
 try:
-    from cms.djangoapps.contentstore.exceptions import AssetNotFoundException
     from opaque_keys.edx.keys import AssetKey
     from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
     from xmodule.contentstore.content import StaticContent
     from xmodule.contentstore.django import contentstore
 except ImportError:
-    AssetNotFoundException = None
     configuration_helpers = None
     StaticContent = None
     contentstore = None
@@ -275,19 +273,10 @@ class ImagesGalleryXBlock(XBlock):
     @XBlock.json_handler
     def remove_files(self, data, suffix=''):  # pylint: disable=unused-argument
         """Handler for removing images from the course assets."""
-        try:
-            from cms.djangoapps.contentstore.views.assets import delete_asset  # pylint: disable=import-outside-toplevel
-        except ImportError:
-            from cms.djangoapps.contentstore.asset_storage_handler import delete_asset  # pylint: disable=import-outside-toplevel
-
         assets = data.get("assets")
 
         for asset_key_id in assets:
             asset_key = AssetKey.from_string(asset_key_id)
-            try:
-                delete_asset(self.course_id, asset_key)
-            except AssetNotFoundException as e:
-                log.exception(e)
 
             for content in self.contents:
                 if content["asset_key"] == str(asset_key):


### PR DESCRIPTION
### Description
This PR corrects the image deletion functionality. From now on it works as follows:
1. When I delete an image from the image gallery XBlock, it is only deleted from the carousel, but not from the assets of the course. 
2. When I delete an image from assets, it is also deleted from the carousel.

**NOTE**: There's a limitation here that we can't avoid given the XBlock architecture, the XBlock state will synchronize with the course assets only when the edit studio view is opened. If not, the students will see out-of-date assets in the XBlock even after deleting them from the course assets.

### How to Test
1. Upload two images to the XBlock. Check that you see them in the carousel, and also from the course assets.
2. Remove the first image from the XBlock. You should not see it in the carousel, but you should see it in the course assets.
3. Remove the second image from the course assets. When you go to the edit view you should not see the image in the carousel.